### PR TITLE
Added support for protocol neutral URLs

### DIFF
--- a/pelican_javascript.py
+++ b/pelican_javascript.py
@@ -7,8 +7,22 @@ articles.
 """
 import os
 import shutil
+import logging
+import pprint
 
 from pelican import signals
+from pelican.settings import DEFAULT_CONFIG
+
+logger = logging.getLogger(__name__)
+
+
+def initialized(pelican):
+
+    DEFAULT_CONFIG.setdefault('PJSCSS_OUTPUT_PATH', '')
+
+    if pelican:
+        pelican.settings.setdefault('PJSCSS_OUTPUT_PATH', '')
+
 
 def copy_resources(src, dest, file_list):
     """
@@ -27,11 +41,13 @@ def copy_resources(src, dest, file_list):
     ------
     Copies files from content to output
     """
+
     if not os.path.exists(dest):
         os.makedirs(dest)
     for file_ in file_list:
         file_src = os.path.join(src, file_)
         shutil.copy2(file_src, dest)
+
 
 def add_files(gen, metadata):
     """
@@ -41,23 +57,26 @@ def add_files(gen, metadata):
     site_url = gen.settings['SITEURL']
     formatters = {'stylesheets': '<link rel="stylesheet" href="{0}" type="text/css" />',
                   'javascripts': '<script src="{0}"></script>'}
-    dirnames = {'stylesheets': 'css',
-                'javascripts': 'js'}
+    dirnames = {'stylesheets': '{0}/css'.format(gen.settings['PJSCSS_OUTPUT_PATH']),
+                'javascripts': '{0}/js'.format(gen.settings['PJSCSS_OUTPUT_PATH'])}
     for key in ['stylesheets', 'javascripts']:
         if key in metadata:
             files = metadata[key].replace(" ", "").split(",")
             htmls = []
             for f in files:
-                if f.startswith('http://') or f.startswith('https://'):
+                if f.startswith('http://') or f.startswith('https://') or f.startswith('//'):
                     link = f
                 else:
                     if gen.settings['RELATIVE_URLS']:
-                        link = "%s/%s" % (dirnames[key], f)
+                        link = '{0}/{1}'.format(dirnames[key], f)
                     else:
-                        link = "%s/%s/%s" % (site_url, dirnames[key], f)
+                        link = '{0}/{1}/{2}'.format(site_url, dirnames[key], f)
                 html = formatters[key].format(link)
+                logger.debug('PJSCSS_Link: {0}'.format(link))
                 htmls.append(html)
             metadata[key] = htmls
+            
+
 
 def move_resources(gen):
     """
@@ -66,10 +85,12 @@ def move_resources(gen):
     js_files = gen.get_files('js', extensions='js')
     css_files = gen.get_files('css', extensions='css')
 
-    js_dest = os.path.join(gen.output_path, 'js')
+    js_dest = os.path.join(gen.output_path, '{0}/js'.format(gen.settings['PJSCSS_OUTPUT_PATH']))
+    logger.debug('PJSCSS_Path:{0}'.format(js_dest))
     copy_resources(gen.path, js_dest, js_files)
 
-    css_dest = os.path.join(gen.output_path, 'css')
+    css_dest = os.path.join(gen.output_path, '{0}/css'.format(gen.settings['PJSCSS_OUTPUT_PATH']))
+    logger.debug('PJSCSS_Path:{0}'.format(css_dest))
     copy_resources(gen.path, css_dest, css_files)
 
 
@@ -77,6 +98,10 @@ def register():
     """
     Plugin registration
     """
-    signals.article_generator_context.connect(add_files)
-    signals.page_generator_context.connect(add_files)
-    signals.article_generator_finalized.connect(move_resources)
+    signals.initialized.connect(initialized)
+    try:
+        signals.article_generator_context.connect(add_files)
+        signals.page_generator_context.connect(add_files)
+        signals.article_generator_finalized.connect(move_resources)
+    except Exception as e:
+        logger.exception('Plugin failed to execute: {}'.format(pprint.pformat(e)))


### PR DESCRIPTION
I have made three code changes:

I have added support for `//` the protocol neutral url prefix.

In my theme the static files are kept in a subfolder called `theme`. In order to keep things tidy, I have added support for output path information.

I have added logging. I needed some debug logging to see what was going on. I left it because it was useful if you are trying to figure out what the plugin is doing.